### PR TITLE
Remove network-api.onefootball.com from doc

### DIFF
--- a/source/api.rst
+++ b/source/api.rst
@@ -24,8 +24,6 @@ Schema
 
 | All API access is over HTTPS. All data is sent and received in JSON format.
 
-| Access is from the following URL: https://network-api.onefootball.com
-
 
 Time format
 ~~~~~~~~~~~


### PR DESCRIPTION
As [discussed](https://onefootball.slack.com/archives/GDHNTSZCK/p1608556389276400?thread_ts=1608554896.274700&cid=GDHNTSZCK) with Manuel Grawe, it seems that this piece of text is
confusing the creators:

> Access is from the following URL: https://network-api.onefootball.com

Because https://network-api.onefootball.com is not a valid endpoint, 
the request returns the following response.
```
{
  "message": "Not Found",  
  "type": "Not Found"
}
```
And this might confuse the creators leading them to think that our API
doesn't work. 

I suggest that we remove this piece of text from the documentation
because is not adding any value.