### PR TITLE
Fix Python3 code example for login

### DIFF
--- a/source/api.rst
+++ b/source/api.rst
@@ -84,18 +84,13 @@ Retrieving an authentication token
    .. code-block:: python
 
       import requests
+      
+      url = 'https://network-api.onefootball.com/v1/login'
+      data = {'login': 'EMAIL_ADDRESS', 'password': 'SECRET_PASSWORD'}
 
-      headers = {
-          'Content-Type': 'application/json',
-      }
-
-      data = {"login": "EMAIL_ADDRESS", "password": "SECRET_PASSWORD"}
-
-      response = requests.post(
-          'https://network-api.onefootball.com/v1/login',
-          headers=headers,
-          data=data
-      )
+      response = requests.post(url, json=data)
+      if response.ok:
+            print(response.json()['access_token'])
 
    .. code-block:: go
 


### PR DESCRIPTION
When testing the API exmaples, the current Python code on the website didn't work.
The applicaiton/json header can be omitted when using the json parameter in the post function.